### PR TITLE
Improve SQL editor IntelliSense

### DIFF
--- a/SQLBasic.net/ViewModels/MainWindowViewModel.cs
+++ b/SQLBasic.net/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
+using System.Linq;
 using System.Windows.Media;
 using System.Xml;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -256,48 +258,180 @@ public partial class MainWindowViewModel : ObservableObject
         }
     }
 
+    private static readonly HashSet<string> SqlClauseKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "on",
+        "using",
+        "where",
+        "group",
+        "order",
+        "inner",
+        "left",
+        "right",
+        "full",
+        "outer",
+        "cross",
+        "join"
+    };
+
     public IEnumerable<string>? OnTextChanged(string documentText, int caretOffset)
     {
-        if (coreService == null)
+        if (coreService == null || string.IsNullOrEmpty(documentText))
         {
             return null;
         }
 
-        var context = GetContextAroundCaret(documentText, caretOffset);
+        caretOffset = Math.Clamp(caretOffset, 0, documentText.Length);
+        string textBeforeCaret = documentText.Substring(0, caretOffset);
 
-        // "." が入力されたらカラム補完
-        // "." 直後ならカラム補完
-        if (context.EndsWith("."))
+        var tableAliases = ParseTableAliases(documentText);
+
+        // ピリオドで区切られたカラム補完
+        var dotMatch = Regex.Match(textBeforeCaret, @"([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]*)$", RegexOptions.IgnoreCase);
+        if (dotMatch.Success)
         {
-            var tableName = GetTableNameBeforeDot(documentText, caretOffset);
-            return coreService.GetColumnNamesOnEditor(tableName);
+            var alias = dotMatch.Groups[1].Value;
+            var columnPrefix = dotMatch.Groups[2].Value;
+
+            var tableName = ResolveTableName(tableAliases, alias);
+            if (!string.IsNullOrEmpty(tableName))
+            {
+                var filteredColumns = FilterByPrefix(coreService.GetColumnNamesOnEditor(tableName), columnPrefix);
+                return filteredColumns.Count > 0 ? filteredColumns : null;
+            }
+
+            return null;
         }
-        // FROM 直後にテーブル補完
-        else if (Regex.IsMatch(documentText, @"\bFROM\s+[a-zA-Z_]*$", RegexOptions.IgnoreCase))
+
+        // FROM 直後はテーブル候補
+        var fromMatch = Regex.Match(textBeforeCaret, @"\bfrom\s+([a-zA-Z0-9_]*)$", RegexOptions.IgnoreCase);
+        if (fromMatch.Success)
         {
-            return coreService.GetTableNamesOnEditor();
+            var tablePrefix = fromMatch.Groups[1].Value;
+            var filteredTables = FilterByPrefix(coreService.GetTableNamesOnEditor(), tablePrefix);
+            return filteredTables.Count > 0 ? filteredTables : null;
         }
+
+        // SELECT ～ FROM の間ではカラム候補
+        var selectMatch = Regex.Match(textBeforeCaret, @"\bselect\b", RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
+        if (selectMatch.Success)
+        {
+            var afterSelect = textBeforeCaret.Substring(selectMatch.Index + selectMatch.Length);
+            if (!Regex.IsMatch(afterSelect, @"\bfrom\b", RegexOptions.IgnoreCase))
+            {
+                var prefixMatch = Regex.Match(textBeforeCaret, @"([a-zA-Z0-9_]*)$");
+                var columnPrefix = prefixMatch.Success ? prefixMatch.Groups[1].Value : string.Empty;
+
+                var tablesForColumns = tableAliases.Values.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                if (tablesForColumns.Count == 0)
+                {
+                    return null;
+                }
+
+                var allColumns = new List<string>();
+                foreach (var table in tablesForColumns)
+                {
+                    allColumns.AddRange(coreService.GetColumnNamesOnEditor(table));
+                }
+
+                var filteredColumns = FilterByPrefix(allColumns, columnPrefix);
+                return filteredColumns.Count > 0 ? filteredColumns : null;
+            }
+        }
+
         return null;
     }
-    // カーソル前後の一部文字列を取得（文脈判定用）
-    private string GetContextAroundCaret(string text, int caretOffset, int contextLength = 6)
-    {
-        if (caretOffset <= 0 || string.IsNullOrEmpty(text))
-            return string.Empty;
 
-        int start = Math.Max(0, caretOffset - contextLength);
-        int length = Math.Min(contextLength, text.Length - start);
-        return text.Substring(start, length);
+    private Dictionary<string, string> ParseTableAliases(string text)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return aliases;
+        }
+
+        foreach (Match match in Regex.Matches(text, @"\b(from|join)\s+([a-zA-Z0-9_]+)(?:\s+(?:as\s+)?([a-zA-Z0-9_]+))?", RegexOptions.IgnoreCase))
+        {
+            AddAlias(aliases, match.Groups[2].Value, match.Groups[3].Success ? match.Groups[3].Value : null);
+        }
+
+        foreach (Match match in Regex.Matches(text, @",\s*([a-zA-Z0-9_]+)(?:\s+(?:as\s+)?([a-zA-Z0-9_]+))?", RegexOptions.IgnoreCase))
+        {
+            AddAlias(aliases, match.Groups[1].Value, match.Groups[2].Success ? match.Groups[2].Value : null);
+        }
+
+        return aliases;
     }
 
-    private string GetTableNameBeforeDot(string text,int caretOffset)
+    private void AddAlias(Dictionary<string, string> aliases, string tableName, string? alias)
     {
-        // caret の直前 50 文字くらいからテーブル名候補を探す
-        int start = Math.Max(0, caretOffset - 50);
-        string context = text.Substring(start, caretOffset - start);
+        if (string.IsNullOrWhiteSpace(tableName))
+        {
+            return;
+        }
 
-        // 例: "FROM student." → student
-        var match = Regex.Match(context, @"([a-zA-Z0-9_]+)\s*\.$", RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : string.Empty;
+        tableName = tableName.Trim();
+        if (!aliases.ContainsKey(tableName))
+        {
+            aliases[tableName] = tableName;
+        }
+
+        if (string.IsNullOrWhiteSpace(alias))
+        {
+            return;
+        }
+
+        alias = alias.Trim();
+        if (!SqlClauseKeywords.Contains(alias) && !aliases.ContainsKey(alias))
+        {
+            aliases[alias] = tableName;
+        }
+    }
+
+    private string? ResolveTableName(Dictionary<string, string> aliases, string aliasOrTable)
+    {
+        if (string.IsNullOrWhiteSpace(aliasOrTable))
+        {
+            return null;
+        }
+
+        if (aliases.TryGetValue(aliasOrTable, out var tableName))
+        {
+            return tableName;
+        }
+
+        return aliasOrTable;
+    }
+
+    private List<string> FilterByPrefix(IEnumerable<string> candidates, string prefix)
+    {
+        var results = new List<string>();
+        if (candidates == null)
+        {
+            return results;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(prefix) && !candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (seen.Add(candidate))
+            {
+                results.Add(candidate);
+            }
+        }
+
+        results.Sort(StringComparer.OrdinalIgnoreCase);
+        return results;
     }
 }


### PR DESCRIPTION
## Summary
- add context-aware completion logic for tables and columns in the SQL editor
- support prefix filtering, alias resolution, and dot-triggered column suggestions to mimic IntelliSense

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e11ec02fc48324a754e05b11a4e456